### PR TITLE
Correct ec2_eni module task to use pre-boto3 authentication

### DIFF
--- a/tasks/eni.yml
+++ b/tasks/eni.yml
@@ -21,8 +21,12 @@
 
     - name: create network interface
       ec2_eni:
+        profile:        '{{ aws_profile }}'
+        aws_access_key: '{{ aws_iam_assume_role_access_key    | default(omit) }}'
+        aws_secret_key: '{{ aws_iam_assume_role_secret_key    | default(omit) }}'
+        security_token: '{{ aws_iam_assume_role_session_token | default(omit) }}'
+
         private_ip_address: '{{ _aws_ec2_i["private_ip"] | default(omit) }}'
-        profile: '{{ aws_profile }}'
         region: '{{ aws_region }}'
         security_groups: '{{ _aws_ec2_i["group"] }}'
         subnet_id: '{{ _aws_ec2_subnet }}'


### PR DESCRIPTION
I mistakenly switched this task to assume that it supports boto3-style automatic role assumption (see b4bf28bd26fcb98d14e210221fc768fb4174e1a3), but that's not actually the case. The other use of this same module in this role is not affected. I didn't notice this before now because this code path is only used when an instance is configured to use an ENI.